### PR TITLE
Fix web socket error handling loop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,8 @@
-/target
+target/
+pkg/
+**/*.rs.bk
+dist/
+traces/
+*.DS_Store
+.cargo/
+.env

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -767,6 +767,7 @@ dependencies = [
  "thiserror 2.0.3",
  "tokio",
  "tokio-tungstenite",
+ "tokio-util",
  "url",
  "zstd",
 ]
@@ -1463,6 +1464,19 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
  "tungstenite",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7fcaa8d55a2bdd6b83ace262b016eca0d79ee02818c5c1bcdf0305114081078"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ zstd = "0.13.2"
 thiserror = "2.0.3"
 flume = "0.11.1"
 log = "0.4.22"
+tokio-util = "0.7.13"
 
 [dev-dependencies]
 anyhow = "1.0.93"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,15 @@ readme = "README.md"
 
 [dependencies]
 async-trait = "0.1.83"
-atrium-api = { version = "0.24.7", default-features = false, features = ["namespace-appbsky"] }
-tokio = { version = "1.41.1", features = ["full", "sync"] }
-tokio-tungstenite = { version = "0.24.0", features = ["connect", "native-tls-vendored", "url"] }
+atrium-api = { version = "0.24.7", default-features = false, features = [
+    "namespace-appbsky",
+] }
+tokio = { version = "1.41.1", features = ["full", "sync", "time"] }
+tokio-tungstenite = { version = "0.24.0", features = [
+    "connect",
+    "native-tls-vendored",
+    "url",
+] }
 futures-util = "0.3.31"
 url = "2.5.3"
 serde = { version = "1.0.215", features = ["derive"] }

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,19 +1,10 @@
 //! A very basic example of how to listen for create/delete events on a specific DID and NSID.
 
-use atrium_api::{
-    record::KnownRecord::AppBskyFeedPost,
-    types::string,
-};
+use atrium_api::{record::KnownRecord::AppBskyFeedPost, types::string};
 use clap::Parser;
 use jetstream_oxide::{
-    events::{
-        commit::CommitEvent,
-        JetstreamEvent::Commit,
-    },
-    DefaultJetstreamEndpoints,
-    JetstreamCompression,
-    JetstreamConfig,
-    JetstreamConnector,
+    events::{commit::CommitEvent, JetstreamEvent::Commit},
+    DefaultJetstreamEndpoints, JetstreamCompression, JetstreamConfig, JetstreamConnector,
 };
 
 #[derive(Parser, Debug)]
@@ -41,7 +32,7 @@ async fn main() -> anyhow::Result<()> {
     };
 
     let jetstream = JetstreamConnector::new(config)?;
-    let (receiver, _) = jetstream.connect().await?;
+    let receiver = jetstream.connect().await?;
 
     println!(
         "Listening for '{}' events on DIDs: {:?}",

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,4 @@
-///! Various error types.
+//! Various error types.
 use std::io;
 
 use thiserror::Error;
@@ -40,6 +40,4 @@ pub enum JetstreamEventError {
     CompressionDecoderError(io::Error),
     #[error("all receivers were dropped but the websocket connection failed to close cleanly")]
     WebSocketCloseFailure,
-    #[error("failed to connect to Jetstream instance: {0}")]
-    WebSocketFailure(#[from] tokio_tungstenite::tungstenite::Error),
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,6 @@
 ///! Various error types.
 use std::io;
 
-
 use thiserror::Error;
 
 /// Possible errors that can occur when a [JetstreamConfig](crate::JetstreamConfig) that is passed
@@ -41,4 +40,6 @@ pub enum JetstreamEventError {
     CompressionDecoderError(io::Error),
     #[error("all receivers were dropped but the websocket connection failed to close cleanly")]
     WebSocketCloseFailure,
+    #[error("failed to connect to Jetstream instance: {0}")]
+    WebSocketFailure(#[from] tokio_tungstenite::tungstenite::Error),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -252,7 +252,7 @@ async fn websocket_task(
                         let event = serde_json::from_str::<JetstreamEvent>(&json)
                             .map_err(JetstreamEventError::ReceivedMalformedJSON)?;
 
-                        if send_channel.send(event).is_ok() {
+                        if send_channel.send(event).is_err() {
                             // We can assume that all receivers have been dropped, so we can close the
                             // connection and exit the task.
                             log::info!(
@@ -277,7 +277,7 @@ async fn websocket_task(
                         let event = serde_json::from_str::<JetstreamEvent>(&json)
                             .map_err(JetstreamEventError::ReceivedMalformedJSON)?;
 
-                        if send_channel.send(event).is_ok() {
+                        if send_channel.send(event).is_err() {
                             // We can assume that all receivers have been dropped, so we can close the
                             // connection and exit the task.
                             log::info!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -238,6 +238,7 @@ impl JetstreamConnector {
                 tokio::time::sleep(Duration::from_millis(delay_ms.min(max_delay_ms))).await;
                 log::info!("Attempting to reconnect...")
             }
+            log::error!("Connection retries exhausted. Jetstream is disconnected.");
         });
 
         Ok(receive_channel)


### PR DESCRIPTION
- Fixes #3 

- Adds websocket "good citizen" practices to keep the jetstream connection alive & reconnect with exponential backoff in the case of failure

- Runs `cargo fmt` & addresses `cargo clippy` warnings (If these conventions are unwanted I can revert them)

- Removes the returned join handle - I couldn't figure out a use case for it but I am happy to undo that change if you'd like.