### PR TITLE
Allows the user to configure retries and reset the retry counter

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,6 @@ cargo run --example basic -- \
 --did "did:plc:inze6wrmsm7pjl7yta3oig77"
 ```
 
-This listens for posts that *I personally make*. You can substitute your own DID and make a few test posts yourself if
+This listens for posts that _I personally make_. You can substitute your own DID and make a few test posts yourself if
 you'd
 like of course!

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -3,8 +3,7 @@
 use atrium_api::{record::KnownRecord::AppBskyFeedPost, types::string};
 use clap::Parser;
 use jetstream_oxide::{
-    events::{commit::CommitEvent, JetstreamEvent::Commit},
-    DefaultJetstreamEndpoints, JetstreamCompression, JetstreamConfig, JetstreamConnector,
+    events::{commit::CommitEvent, JetstreamEvent::Commit}, DefaultJetstreamEndpoints, JetstreamCompression, JetstreamConfig, JetstreamConnector
 };
 
 #[derive(Parser, Debug)]
@@ -29,6 +28,10 @@ async fn main() -> anyhow::Result<()> {
         wanted_dids: dids.clone(),
         compression: JetstreamCompression::Zstd,
         cursor: None,
+        max_retries: 10,
+        max_delay_ms: 30_000,
+        base_delay_ms: 1_000,
+        reset_retries_min_ms: 30_000
     };
 
     let jetstream = JetstreamConnector::new(config)?;


### PR DESCRIPTION
This pull requests does two things:

1. Adds a retries configuration to the "connect" method
2. "resets" the retries counter when a connection to the jetstream is stablished. Currently, when a connection with the jetstream is lost, the code will try to re-stablish the connection but the retries counter is not reset and therefore after 10 disconnections, no new reconnect attempts will be tried. I don't know what the expected behavior actually is after a disconnect, but I think that if it is expected for connect to try to re-connect, the retries counter should be reset.



