### PR TITLE
update atrium-api version to that used by bsky-sdk

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 
 [dependencies]
 async-trait = "0.1.83"
-atrium-api = { version = "0.24.7", default-features = false, features = [
+atrium-api = { version = "0.25", default-features = false, features = [
     "namespace-appbsky",
 ] }
 tokio = { version = "1.41.1", features = ["full", "sync", "time"] }


### PR DESCRIPTION
In order to have an app using both bsky-sdk and this, they need to use compatible versions of the atrium-api crate. jetstream-oxide was using an older version, so this PR updates it to match that used in bsky-sdk, and now they can play happily together.