### PR TITLE
Bug: update commits are parsed as CommitEvent::Create

### DIFF
--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -29,3 +29,34 @@ pub enum EventKind {
     Identity,
     Account,
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    const UPDATE_EVENT: &str = r#"{
+          "did": "did:plc:z72i7hdynmk6r22z27h6tvur",
+          "time_us": 1742234149201771,
+          "kind": "commit",
+          "commit": {
+            "rev": "3lklpzt6jvf2n",
+            "operation": "update",
+            "collection": "app.bsky.actor.profile",
+            "rkey": "self",
+            "record": { "$type": "app.bsky.actor.profile" },
+            "cid": "bafyreie4x2nfhr7zbeuwfuad7ess3mlpudgab7cqw3b4rqiormnq726spu"
+          }
+        }
+    "#;
+
+    #[test]
+    fn regression_update_parsed_as_create() {
+        let parsed: JetstreamEvent = serde_json::from_str(UPDATE_EVENT).unwrap();
+        let JetstreamEvent::Commit(c) = parsed else {
+            panic!("expected a commit event, found {:?}", parsed);
+        };
+        let commit::CommitEvent::Update { .. } = c else {
+            panic!("expected an update commit, found {:?}", c);
+        };
+    }
+}


### PR DESCRIPTION
...instead of CommitEvent::Update

This PR currently just adds a failing test case. I'll get back eventually to try and offer a fix, but if anyone wants to pick it up from here please do. It might be a little while for me.
