### PR TITLE
fixes the bug of commit updates being deserialized as create commits.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,16 +18,16 @@ let jetstream = JetstreamConnector::new(config).unwrap();
 let receiver = jetstream.connect().await?;
 
 while let Ok(event) = receiver.recv_async().await {
-    if let Commit(commit) = event {
-        match commit {
-            CommitEvent::Create { info, commit } => {
-                println!("Received create event: {:#?}", info);
+    if let Commit(commit_event) = event {
+        match commit_event.commit {
+            CommitData::Create { .. } => {
+                println!("Received create event: {:#?}", commit_event.info);
             }
-            CommitEvent::Update { info, commit } => {
-                println!("Received update event: {:#?}", info);
+            CommitData::Update { .. } => {
+                println!("Received update event: {:#?}", commit_event.info);
             }
-            CommitEvent::Delete { info, commit } => {
-                println!("Received delete event: {:#?}", info);
+            CommitData::Delete { .. } => {
+                println!("Received delete event: {:#?}", commit_event.info);
             }
         }
     }

--- a/src/events/account.rs
+++ b/src/events/account.rs
@@ -1,13 +1,11 @@
 use chrono::Utc;
 use serde::Deserialize;
 
-use crate::{
-    events::EventInfo,
-    exports,
-};
+use crate::{events::EventInfo, exports};
 
 /// An event representing a change to an account.
 #[derive(Deserialize, Debug)]
+#[cfg_attr(test, derive(PartialEq))]
 pub struct AccountEvent {
     /// Basic metadata included with every event.
     #[serde(flatten)]
@@ -18,6 +16,7 @@ pub struct AccountEvent {
 
 /// Account specific data bundled with an account event.
 #[derive(Deserialize, Debug)]
+#[cfg_attr(test, derive(PartialEq))]
 pub struct AccountData {
     /// Whether the account is currently active.
     pub active: bool,
@@ -31,6 +30,7 @@ pub struct AccountData {
 
 /// The possible reasons an account might be listed as inactive.
 #[derive(Deserialize, Debug)]
+#[cfg_attr(test, derive(PartialEq))]
 #[serde(rename_all = "lowercase")]
 pub enum AccountStatus {
     Deactivated,

--- a/src/events/commit.rs
+++ b/src/events/commit.rs
@@ -1,61 +1,52 @@
 use atrium_api::record::KnownRecord;
 use serde::Deserialize;
 
-use crate::{
-    events::EventInfo,
-    exports,
-};
+use crate::{events::EventInfo, exports};
 
-/// An event representing a repo commit, which can be a `create`, `update`, or `delete` operation.
+/// An event representing a repo commit.
 #[derive(Deserialize, Debug)]
-#[serde(untagged, rename_all = "snake_case")]
-pub enum CommitEvent {
-    Create {
-        #[serde(flatten)]
-        info: EventInfo,
-        commit: CommitData,
-    },
-    Update {
-        #[serde(flatten)]
-        info: EventInfo,
-        commit: CommitData,
-    },
-    Delete {
-        #[serde(flatten)]
-        info: EventInfo,
-        commit: CommitInfo,
-    },
-}
-
-/// The type of commit operation that was performed.
-#[derive(Deserialize, Debug)]
+#[cfg_attr(test, derive(PartialEq))]
 #[serde(rename_all = "snake_case")]
-pub enum CommitType {
-    Create,
-    Update,
-    Delete,
+pub struct CommitEvent {
+    #[serde(flatten)]
+    pub info: EventInfo,
+    pub commit: CommitData,
 }
 
 /// Basic commit specific info bundled with every event, also the only data included with a `delete`
 /// operation.
 #[derive(Deserialize, Debug)]
+#[cfg_attr(test, derive(PartialEq))]
 pub struct CommitInfo {
-    /// The type of commit operation that was performed.
-    pub operation: CommitType,
     pub rev: String,
     pub rkey: String,
     /// The NSID of the record type that this commit is associated with.
     pub collection: exports::Nsid,
 }
 
-/// Detailed data bundled with a commit event. This data is only included when the event is
-/// `create` or `update`.
+/// Detailed data bundled with a commit event.
 #[derive(Deserialize, Debug)]
-pub struct CommitData {
-    #[serde(flatten)]
-    pub info: CommitInfo,
-    /// The CID of the record that was operated on.
-    pub cid: exports::Cid,
-    /// The record that was operated on.
-    pub record: KnownRecord,
+#[cfg_attr(test, derive(PartialEq))]
+#[serde(tag = "operation", rename_all = "snake_case")]
+pub enum CommitData {
+    Create {
+        #[serde(flatten)]
+        info: CommitInfo,
+        /// The CID of the record that was operated on.
+        cid: exports::Cid,
+        /// The record that was operated on.
+        record: KnownRecord,
+    },
+    Update {
+        #[serde(flatten)]
+        info: CommitInfo,
+        /// The CID of the record that was operated on.
+        cid: exports::Cid,
+        /// The record that was operated on.
+        record: KnownRecord,
+    },
+    Delete {
+        #[serde(flatten)]
+        info: CommitInfo,
+    },
 }

--- a/src/events/identity.rs
+++ b/src/events/identity.rs
@@ -1,13 +1,11 @@
 use chrono::Utc;
 use serde::Deserialize;
 
-use crate::{
-    events::EventInfo,
-    exports,
-};
+use crate::{events::EventInfo, exports};
 
 /// An event representing a change to an identity.
 #[derive(Deserialize, Debug)]
+#[cfg_attr(test, derive(PartialEq))]
 pub struct IdentityEvent {
     /// Basic metadata included with every event.
     #[serde(flatten)]
@@ -18,6 +16,7 @@ pub struct IdentityEvent {
 
 /// Identity specific data bundled with an identity event.
 #[derive(Deserialize, Debug)]
+#[cfg_attr(test, derive(PartialEq))]
 pub struct IdentityData {
     /// The DID of the identity.
     pub did: exports::Did,

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -8,24 +8,207 @@ use crate::exports;
 
 /// Basic data that is included with every event.
 #[derive(Deserialize, Debug)]
+#[cfg_attr(test, derive(PartialEq))]
 pub struct EventInfo {
     pub did: exports::Did,
     pub time_us: u64,
-    pub kind: EventKind,
 }
 
 #[derive(Deserialize, Debug)]
-#[serde(untagged)]
+#[cfg_attr(test, derive(PartialEq))]
+#[serde(tag = "kind", rename_all = "snake_case")]
 pub enum JetstreamEvent {
     Commit(commit::CommitEvent),
     Identity(identity::IdentityEvent),
     Account(account::AccountEvent),
 }
 
-#[derive(Deserialize, Debug)]
-#[serde(rename_all = "snake_case")]
-pub enum EventKind {
-    Commit,
-    Identity,
-    Account,
+#[cfg(test)]
+mod test {
+
+    use super::{commit::CommitData, *};
+    use std::str::FromStr;
+
+    #[test]
+    fn parse_commit_update() {
+        let event_json: &str = r#"{
+            "did": "did:plc:z72i7hdynmk6r22z27h6tvur",
+            "time_us": 1742234149201771,
+            "kind": "commit",
+            "commit": {
+              "rev": "3lklpzt6jvf2n",
+              "operation": "update",
+              "collection": "app.bsky.actor.profile",
+              "rkey": "self",
+              "record": { "$type": "app.bsky.actor.profile" },
+              "cid": "bafyreie4x2nfhr7zbeuwfuad7ess3mlpudgab7cqw3b4rqiormnq726spu"
+            }
+          }
+        "#;
+
+        let event_expected_object = JetstreamEvent::Commit(commit::CommitEvent {
+            info: EventInfo {
+                did: exports::Did::new("did:plc:z72i7hdynmk6r22z27h6tvur".to_string()).unwrap(),
+                time_us: 1742234149201771,
+            },
+            commit: CommitData::Update {
+                info: commit::CommitInfo {
+                    rev: "3lklpzt6jvf2n".into(),
+                    rkey: "self".into(),
+                    collection: exports::Nsid::new("app.bsky.actor.profile".to_string()).unwrap(),
+                },
+                cid: exports::Cid::from_str(
+                    "bafyreie4x2nfhr7zbeuwfuad7ess3mlpudgab7cqw3b4rqiormnq726spu",
+                )
+                .unwrap(),
+                record: serde_json::from_str(r#"{ "$type": "app.bsky.actor.profile" }"#).unwrap(),
+            },
+        });
+
+        let parsed: JetstreamEvent = serde_json::from_str(event_json).unwrap();
+
+        assert_eq!(parsed, event_expected_object);
+    }
+
+    #[test]
+    fn parse_commit_create() {
+        let event_json: &str = r#"{
+            "did": "did:plc:z72i7hdynmk6r22z27h6tvur",
+            "time_us": 1742234149201771,
+            "kind": "commit",
+            "commit": {
+              "rev": "3lklpzt6jvf2n",
+              "operation": "create",
+              "collection": "app.bsky.actor.profile",
+              "rkey": "self",
+              "record": { "$type": "app.bsky.actor.profile" },
+              "cid": "bafyreie4x2nfhr7zbeuwfuad7ess3mlpudgab7cqw3b4rqiormnq726spu"
+            }
+          }
+        "#;
+
+        let event_expected_object = JetstreamEvent::Commit(commit::CommitEvent {
+            info: EventInfo {
+                did: exports::Did::new("did:plc:z72i7hdynmk6r22z27h6tvur".to_string()).unwrap(),
+                time_us: 1742234149201771,
+            },
+            commit: CommitData::Create {
+                info: commit::CommitInfo {
+                    rev: "3lklpzt6jvf2n".into(),
+                    rkey: "self".into(),
+                    collection: exports::Nsid::new("app.bsky.actor.profile".to_string()).unwrap(),
+                },
+                cid: exports::Cid::from_str(
+                    "bafyreie4x2nfhr7zbeuwfuad7ess3mlpudgab7cqw3b4rqiormnq726spu",
+                )
+                .unwrap(),
+                record: serde_json::from_str(r#"{ "$type": "app.bsky.actor.profile" }"#).unwrap(),
+            },
+        });
+
+        let parsed: JetstreamEvent = serde_json::from_str(event_json).unwrap();
+        assert_eq!(parsed, event_expected_object);
+    }
+
+    #[test]
+    fn parse_commit_delete() {
+        let event_json: &str = r#"{
+            "did": "did:plc:rfov6bpyztcnedeyyzgfq42k",
+            "time_us": 1725516666833633,
+            "kind": "commit",
+            "commit": {
+              "rev": "3l3f6nzl3cv2s",
+              "operation": "delete",
+              "collection": "app.bsky.graph.follow",
+              "rkey": "3l3dn7tku762u"
+            }
+          }
+        "#;
+
+        let event_expected_object = JetstreamEvent::Commit(commit::CommitEvent {
+            info: EventInfo {
+                did: exports::Did::new("did:plc:rfov6bpyztcnedeyyzgfq42k".to_string()).unwrap(),
+                time_us: 1725516666833633,
+            },
+            commit: CommitData::Delete {
+                info: commit::CommitInfo {
+                    rev: "3l3f6nzl3cv2s".into(),
+                    rkey: "3l3dn7tku762u".into(),
+                    collection: exports::Nsid::new("app.bsky.graph.follow".to_string()).unwrap(),
+                },
+            },
+        });
+
+        let parsed: JetstreamEvent = serde_json::from_str(event_json).unwrap();
+        assert_eq!(parsed, event_expected_object);
+    }
+
+    #[test]
+    fn parse_account() {
+        let event_json: &str = r#"{
+            "did": "did:plc:z72i7hdynmk6r22z27h6tvur",
+            "time_us": 1742234149201771,
+            "kind": "account",
+            "account": {
+              "active": true,
+              "did": "did:plc:z72i7hdynmk6r22z27h6tvur",
+              "seq": 1,
+              "time": "2021-09-01T00:00:00Z"
+            }
+          }
+        "#;
+
+        let event_expected_object = JetstreamEvent::Account(account::AccountEvent {
+            info: EventInfo {
+                did: exports::Did::new("did:plc:z72i7hdynmk6r22z27h6tvur".to_string()).unwrap(),
+                time_us: 1742234149201771,
+            },
+            account: account::AccountData {
+                active: true,
+                did: exports::Did::new("did:plc:z72i7hdynmk6r22z27h6tvur".to_string()).unwrap(),
+                seq: 1,
+                time: chrono::DateTime::parse_from_rfc3339("2021-09-01T00:00:00Z")
+                    .unwrap()
+                    .with_timezone(&chrono::Utc),
+                status: None,
+            },
+        });
+
+        let parsed: JetstreamEvent = serde_json::from_str(event_json).unwrap();
+        assert_eq!(parsed, event_expected_object);
+    }
+
+    #[test]
+    fn parse_identity() {
+        let event_json: &str = r#"{
+            "did": "did:plc:4ysnxi6vujpjhovgtn5k4ztr",
+            "time_us": 1742234149201771,
+            "kind": "identity",
+            "identity": {
+              "did": "did:plc:4ysnxi6vujpjhovgtn5k4ztr",
+              "handle": "sergio.bsky.col.social",
+              "seq": 1,
+              "time": "2021-09-01T00:00:00Z"
+            }
+          }
+        "#;
+
+        let event_expected_object = JetstreamEvent::Identity(identity::IdentityEvent {
+            info: EventInfo {
+                did: exports::Did::new("did:plc:4ysnxi6vujpjhovgtn5k4ztr".to_string()).unwrap(),
+                time_us: 1742234149201771,
+            },
+            identity: identity::IdentityData {
+                did: exports::Did::new("did:plc:4ysnxi6vujpjhovgtn5k4ztr".to_string()).unwrap(),
+                handle: Some(exports::Handle::new("sergio.bsky.col.social".to_string()).unwrap()),
+                seq: 1,
+                time: chrono::DateTime::parse_from_rfc3339("2021-09-01T00:00:00Z")
+                    .unwrap()
+                    .with_timezone(&chrono::Utc),
+            },
+        });
+
+        let parsed: JetstreamEvent = serde_json::from_str(event_json).unwrap();
+        assert_eq!(parsed, event_expected_object);
+    }
 }


### PR DESCRIPTION
This is a fix for the problem raised by @uniphil concerning updates commits being parsed as create commits : https://github.com/videah/jetstream-oxide/pull/9 . 

Unfortunately my serde knowledge was not good enough to make this work without breaking changes of the current API (or implementing some custom serde deserialization).

The strategy is to transform the `CommitEvent` into a struct (instead of the current enum), where the field `commit` is a new enum named `CommitData`, which allows me to use the json field `operation` as the tag to resolve the type. Also, while not necessary to fix the bug, I also changed the JetstreamEvent so that it uses the field `kind` as a tag to resolve the type, for consistency (and because it feels less fragile than serde untagged heuristic, and perhaps faster?).

I also added a bunch of deserialization tests.